### PR TITLE
release v1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 All notable changes to the "action-sqlcheck" will be documented in this file.
 
-## 1.2.0
+## 1.2.1
+- No longer use the latest sqlcheck BUT `sqlcheck v1.2` for immutability
+- fix entrypoint.sh as sqlcheck v1.2 exits with code 0 even if anti-patterns or hints are found
 - Change base image from alpine to ubuntu to speed up the action spin up
 
 ## 1.1.0

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
-    - uses: yokawasa/action-sqlcheck@v1.1.0
+    - uses: yokawasa/action-sqlcheck@v1.2.1
       with:
         post-comment: true
         risk-level: 3

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -79,8 +79,9 @@ main() {
       else
         /usr/bin/sqlcheck -r ${RISK_LEVEL} -f ${sql_file} > ${output_file}
       fi
-      RET=$?
-      if [ $RET -ne 0 ]; then   # risk found
+      if grep "^No issues found." ${output_file} > /dev/null 2>&1; then
+        echo "NO issues found: ${sql_file}"
+      else  # Issues found
         risk_files[${risk_found_c}]=${sql_file}
         risk_outputs[${risk_found_c}]=${output_file}
         (( risk_found_c++ ))


### PR DESCRIPTION
- No longer use the latest sqlcheck BUT `sqlcheck v1.2` for immutability
- fix entrypoint.sh as sqlcheck v1.2 exits with code 0 even if anti-patterns or hints are found
- Change base image from alpine to ubuntu to speed up the action spin u