### PR TITLE
V1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,19 +2,25 @@
 
 All notable changes to the "action-sqlcheck" will be documented in this file.
 
+## 1.3.0
+
+- Add input paramter `directories` that allow you to add path(s) of directory under which the action check any files whether they are part of the repository or not. By default, the action checks only files in PR queries - [issue #16](https://github.com/yokawasa/action-sqlcheck/issues/16)
+- Add output variable `issue-found` that is a boolean value to indicate an issue was found in the files that sqlcheck action checked
+
 ## 1.2.1
+
 - No longer use the latest sqlcheck BUT `sqlcheck v1.2` for immutability
 - fix entrypoint.sh as sqlcheck v1.2 exits with code 0 even if anti-patterns or hints are found
 - Change base image from alpine to ubuntu to speed up the action spin up
 
 ## 1.1.0
-- Fixup a bug (PR #12) thanks to @NathanBurkett - The cURL request fails if the repository is not public
+- Fixup a bug ([PR #12](https://github.com/yokawasa/action-sqlcheck/pull/12)) thanks to @NathanBurkett - The cURL request fails if the repository is not public
 
 ## 1.0.0
-- Add Input parameter `verbose` to include verbose warning to the analysis result
+- Add input parameter `verbose` to include verbose warning to the analysis result
 
 ## 0.0.5
-- Add new input parameter: risk-level
+- Add new input parameter `risk-level`
 
 ## 0.0.4
 - Use API to get pull request files and no longer use git command

--- a/README.md
+++ b/README.md
@@ -15,17 +15,19 @@ Supports `pull_request` event type.
 |`token`|true|""|GitHub Token in order to add comment to PR|
 |`risk-level`|false|3|Set of SQL anti-patterns to check: 1,2, or 3<br>- 1 (all anti-patterns, default)<br>- 2 (only medium and high risk anti-patterns)<br> - 3 (only high risk anti-patterns) |
 |`verbose`|false|false|Add verbose warnings to SQLCheck analysis result|
-|`postfixes`|false|"sql"|List of file postfix to match |
-|`directories`|false|""| Path(s) of directory under which the action check any files whether they are part of the repository or not. By default, the action checks only files in PR queries. By specifying directories the action no longer check files in PR queries but files under the directories (maxdepth 3)|
+|`postfixes`|false|"sql"| List of file postfix to match. Supported separators are comma (deprecating) and retrun in multi-line string |
+|`directories`|false|""| Path(s) of directory under which the action check any files whether they are part of the repository or not. By default, the action checks only files in PR queries. By specifying directories the action no longer check files in PR queries but files under the directories (maxdepth 3). Supported separator is return in multi-line string |
 
 ### Outputs
+
 |Parameter|Description|
 |:--:|:--:|
-|`issue-found`| A boolean value to indicate an issue was found in the files that sqlcheck action checked|
-
+|`issue-found`| A boolean value to indicate an issue was found in the files that sqlcheck action checked |
 
 ## Sample Workflow
+
 ### Sample1
+
 > .github/workflows/test1.yml
 
 ```yaml
@@ -47,6 +49,7 @@ jobs:
 ```
 
 ### Sample2 ( postfixes and directories inputs )
+
 > .github/workflows/test2.yml
 
 ```yaml

--- a/README.md
+++ b/README.md
@@ -15,22 +15,30 @@ Supports `pull_request` event type.
 |`token`|true|""|GitHub Token in order to add comment to PR|
 |`risk-level`|false|3|Set of SQL anti-patterns to check: 1,2, or 3<br>- 1 (all anti-patterns, default)<br>- 2 (only medium and high risk anti-patterns)<br> - 3 (only high risk anti-patterns) |
 |`verbose`|false|false|Add verbose warnings to SQLCheck analysis result|
-|`postfixes`|false|"sql"|List of file postfix to match ( separator: comma )|
+|`postfixes`|false|"sql"|List of file postfix to match |
+|`directories`|false|""| Path(s) of directory under which the action check any files whether they are part of the repository or not. By default, the action checks only files in PR queries. By specifying directories the action no longer check files in PR queries but files under the directories (maxdepth 3)|
+
+### Outputs
+|Parameter|Description|
+|:--:|:--:|
+|`issue-found`| A boolean value to indicate an issue was found in the files that sqlcheck action checked|
+
 
 ## Sample Workflow
+### Sample1
+> .github/workflows/test1.yml
 
-> examples/workflow.yml
-```yml
-name: sqlcheck workflow
+```yaml
+name: sqlcheck workflow1
 on: pull_request
 
 jobs:
   sqlcheck:
-    name: sqlcheck job 
+    name: sqlcheck job
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
-    - uses: yokawasa/action-sqlcheck@v1.2.1
+    - uses: yokawasa/action-sqlcheck@v1.3.0
       with:
         post-comment: true
         risk-level: 3
@@ -38,3 +46,35 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}
 ```
 
+### Sample2 ( postfixes and directories inputs )
+> .github/workflows/test2.yml
+
+```yaml
+name: sqlcheck workflow2
+on: pull_request
+
+jobs:
+  sqlcheck:
+    name: sqlcheck job
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - uses: yokawasa/action-sqlcheck@v1.3.0
+      id: sqlcheck
+      with:
+        post-comment: true
+        risk-level: 3
+        verbose: true
+        token: ${{ secrets.GITHUB_TOKEN }}
+        postfixes: |
+          sql
+          sqlx
+          schema
+        directories: |
+          sql
+          build/sql_dir
+          tests/sql_dir
+    - name: Get output
+      run: echo "Issues found in previous step"
+      if: steps.sqlcheck.outputs.issue-found
+```

--- a/action.yml
+++ b/action.yml
@@ -22,6 +22,13 @@ inputs:
     description: "List of file postfix to match ( separator: comma )"
     default: "sql"
     required: false
+  directories:
+    description: "Path(s) of directory under which the action check any files whether they are part of the repository or not. By default, the action checks only files in PR queries. By specifying directories the action no longer check files in PR queries but files under the directories"
+    default: ""
+    required: false
+outputs:
+  issue-found:
+    description: 'A boolean value to indicate an issue was found in the files that sqlcheck action checked'
 runs:
   using: "docker"
   image: "Dockerfile"
@@ -31,6 +38,7 @@ runs:
     - ${{ inputs.risk-level }}
     - ${{ inputs.verbose }}
     - ${{ inputs.postfixes }}
+    - ${{ inputs.directories }}
 branding:
   icon: 'check-circle'
   color: 'black'


### PR DESCRIPTION
- Add input paramter `directories` that allow you to add path(s) of directory under which the action check any files whether they are part of the repository or not. By default, the action checks only files in PR queries - [issue #16](https://github.com/yokawasa/action-sqlcheck/issues/16)
- Add output variable `issue-found` that is a boolean value to indicate an issue was found in the files that sqlcheck action checked