### PR TITLE
Updated to yokawasa/action-sqlcheck@v1.4.0 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
-    - uses: yokawasa/action-sqlcheck@v1.3.0
+    - uses: yokawasa/action-sqlcheck@v1.4.0
       with:
         post-comment: true
         risk-level: 3
@@ -62,7 +62,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
-    - uses: yokawasa/action-sqlcheck@v1.3.0
+    - uses: yokawasa/action-sqlcheck@v1.4.0
       id: sqlcheck
       with:
         post-comment: true


### PR DESCRIPTION
Updated sample workflow to use `yokawasa/action-sqlcheck@v1.4.0` in README before tagging `v.1.4.0` that will include  https://github.com/yokawasa/action-sqlcheck/pull/19
